### PR TITLE
burst tagger: Fixed off-by-one in get_tags_in_range() usage

### DIFF
--- a/lib/burst_tagger_impl.cc
+++ b/lib/burst_tagger_impl.cc
@@ -73,8 +73,7 @@ burst_tagger_impl::work(int noutput_items,
 		std::vector<gr::tag_t> tags;
 		const uint64_t nread = nitems_read(0);
 
-		get_tags_in_range(tags, 0, nread, nread + noutput_items - 1,
-			d_tag_name);
+		get_tags_in_range(tags, 0, nread, nread + noutput_items, d_tag_name);
 		std::sort(tags.begin(), tags.end(), tag_t::offset_compare);
 
 		// copy until the first tag


### PR DESCRIPTION
I've observed missing "tx_sob" tags in case where d_tag_name is associated with the last sample provided to work().

This is caused by the upper-bound provided to `get_tags_in_range()` being 1 less than it should be.

Per the documentation of `get_tags_in_range()` (as of v3.7.7.1), the `abs_end` value is exclusive:

```
  "Given a [start,end), returns a vector of all tags in the range with a given key."
```

Therefore, the upper limit should be:
    `nread + nouput_items`
not
    `nread + noutput_items - 1`

Example:

```
    let nread = 100
    let noutput_items = 100

    We want tags within:
        [100, 199] = [nread, n_read + n_output_items - 1]

    Represented with an exclusive upper bound, as required by get_tags_in_range():
        [100, 200) = [nread, n_read + nouput_items)
```