### PR TITLE
Fixed issue with boost 1.67 time_duration values

### DIFF
--- a/grc/foo_periodic_msg_source.xml
+++ b/grc/foo_periodic_msg_source.xml
@@ -17,7 +17,7 @@
 		<name>Period (ms)</name>
 		<key>interval</key>
 		<value>1000</value>
-		<type>real</type>
+		<type>int</type>
 	</param>
 	<param>
 		<name>Quit</name>

--- a/grc/foo_random_periodic_msg_source.xml
+++ b/grc/foo_random_periodic_msg_source.xml
@@ -17,7 +17,7 @@
 		<name>Period (ms)</name>
 		<key>interval</key>
 		<value>1000</value>
-		<type>real</type>
+		<type>int</type>
 	</param>
 	<param>
 		<name>Quit</name>

--- a/include/foo/periodic_msg_source.h
+++ b/include/foo/periodic_msg_source.h
@@ -28,14 +28,14 @@ class FOO_API periodic_msg_source : virtual public gr::block
 public:
 
 	typedef boost::shared_ptr<periodic_msg_source> sptr;
-	static sptr make(pmt::pmt_t msg, float interval, int num_msg = -1,
+	static sptr make(pmt::pmt_t msg, long interval, int num_msg = -1,
 			bool quit = true, bool debug = false);
 
 	virtual void set_nmsg(int nmsg) = 0;
 	virtual int get_nmsg() = 0;
 
-	virtual void set_delay(float delay) = 0;
-	virtual float get_delay() = 0;
+	virtual void set_delay(long delay) = 0;
+	virtual long get_delay() = 0;
 
 	virtual void start_tx() = 0;
 	virtual void stop_tx() = 0;

--- a/include/foo/random_periodic_msg_source.h
+++ b/include/foo/random_periodic_msg_source.h
@@ -29,14 +29,14 @@ class FOO_API random_periodic_msg_source : virtual public gr::block
 public:
 
 	typedef boost::shared_ptr<random_periodic_msg_source> sptr;
-	static sptr make(int msg_len, float interval, int num_msg = 1,
+	static sptr make(int msg_len, long interval, int num_msg = 1,
 			bool quit = true, bool debug = false, int seed = 0);
 
 	virtual void set_nmsg(int nmsg) = 0;
 	virtual int get_nmsg() = 0;
 
-	virtual void set_delay(float delay) = 0;
-	virtual float get_delay() = 0;
+	virtual void set_delay(long delay) = 0;
+	virtual long get_delay() = 0;
 
 	virtual void start_tx() = 0;
 	virtual void stop_tx() = 0;

--- a/lib/periodic_msg_source_impl.cc
+++ b/lib/periodic_msg_source_impl.cc
@@ -25,7 +25,7 @@ using namespace gr::foo;
 #define dout d_debug && std::cout
 
 periodic_msg_source_impl::periodic_msg_source_impl(pmt::pmt_t msg,
-			float interval, int num_msg, bool quit, bool debug) :
+			long interval, int num_msg, bool quit, bool debug) :
 		block("periodic_msg_source",
 				gr::io_signature::make(0, 0, 0),
 				gr::io_signature::make(0, 0, 0)),
@@ -60,7 +60,7 @@ periodic_msg_source_impl::run(periodic_msg_source_impl *instance) {
 	boost::this_thread::sleep(boost::posix_time::milliseconds(500));
 
 	while(1) {
-		float delay;
+		long delay;
 		{
 			gr::thread::scoped_lock(d_mutex);
 			if(d_finished || !d_nmsg_left) {
@@ -111,12 +111,12 @@ periodic_msg_source_impl::get_nmsg() {
 }
 
 void
-periodic_msg_source_impl::set_delay(float delay) {
+periodic_msg_source_impl::set_delay(long delay) {
 	gr::thread::scoped_lock(d_mutex);
 	d_interval = delay;
 }
 
-float
+long
 periodic_msg_source_impl::get_delay() {
 	gr::thread::scoped_lock(d_mutex);
 	return d_interval;
@@ -148,6 +148,6 @@ periodic_msg_source_impl::is_running() {
 }
 
 periodic_msg_source::sptr
-periodic_msg_source::make(pmt::pmt_t msg, float interval, int num_msg, bool quit, bool debug) {
+periodic_msg_source::make(pmt::pmt_t msg, long interval, int num_msg, bool quit, bool debug) {
 	return gnuradio::get_initial_sptr(new periodic_msg_source_impl(msg, interval, num_msg, quit, debug));
 }

--- a/lib/periodic_msg_source_impl.h
+++ b/lib/periodic_msg_source_impl.h
@@ -31,22 +31,22 @@ namespace foo {
 			bool d_debug;
 			bool d_quit;
 			bool d_finished;
-			float d_interval;
+			long d_interval;
 			pmt::pmt_t d_msg;
 			boost::thread *d_thread;
 			gr::thread::mutex d_mutex;
 
 		public:
 			periodic_msg_source_impl(pmt::pmt_t msg,
-					float interval, int num_msg,
+					long interval, int num_msg,
 					bool quit, bool debug);
 			virtual ~periodic_msg_source_impl();
 
 			void set_nmsg(int nmsg);
 			int get_nmsg();
 
-			void set_delay(float delay);
-			float get_delay();
+			void set_delay(long delay);
+			long get_delay();
 
 			void start_tx();
 			void stop_tx();

--- a/lib/random_periodic_msg_source_impl.cc
+++ b/lib/random_periodic_msg_source_impl.cc
@@ -27,7 +27,7 @@ using namespace gr::foo;
 #define dout d_debug && std::cout
 
 random_periodic_msg_source_impl::random_periodic_msg_source_impl(int msg_len,
-			float interval, int num_msg, bool quit, bool debug, int seed):
+			long interval, int num_msg, bool quit, bool debug, int seed):
 		block("random_periodic_msg_source",
 				gr::io_signature::make(0, 0, 0),
 				gr::io_signature::make(0, 0, 0)),
@@ -65,7 +65,7 @@ random_periodic_msg_source_impl::run(random_periodic_msg_source_impl *instance) 
 	boost::this_thread::sleep(boost::posix_time::milliseconds(500));
 
 	while(1) {
-		float delay;
+		long delay;
 		{
 			gr::thread::scoped_lock(d_mutex);
 			if(d_finished || !d_nmsg_left) {
@@ -129,12 +129,12 @@ random_periodic_msg_source_impl::get_nmsg() {
 }
 
 void
-random_periodic_msg_source_impl::set_delay(float delay) {
+random_periodic_msg_source_impl::set_delay(long delay) {
 	gr::thread::scoped_lock(d_mutex);
 	d_interval = delay;
 }
 
-float
+long
 random_periodic_msg_source_impl::get_delay() {
 	gr::thread::scoped_lock(d_mutex);
 	return d_interval;
@@ -166,7 +166,7 @@ random_periodic_msg_source_impl::is_running() {
 }
 
 random_periodic_msg_source::sptr
-random_periodic_msg_source::make(int msg_len, float interval, int num_msg, 
+random_periodic_msg_source::make(int msg_len, long interval, int num_msg, 
 		bool quit, bool debug,int seed) {
 	return gnuradio::get_initial_sptr(new random_periodic_msg_source_impl(msg_len, interval, num_msg, quit, debug, seed));
 }

--- a/lib/random_periodic_msg_source_impl.h
+++ b/lib/random_periodic_msg_source_impl.h
@@ -35,7 +35,7 @@ namespace foo {
 			bool d_debug;
 			bool d_quit;
 			bool d_finished;
-			float d_interval;
+			long d_interval;
 			boost::thread *d_thread;
 			gr::thread::mutex d_mutex;
 			boost::mt19937 d_rng;
@@ -44,15 +44,15 @@ namespace foo {
 
 		public:
 			random_periodic_msg_source_impl(int msg_len,
-					float interval, int num_msg,
+					long interval, int num_msg,
 					bool quit, bool debug, int seed);
 			virtual ~random_periodic_msg_source_impl();
 
 			void set_nmsg(int nmsg);
 			int get_nmsg();
 
-			void set_delay(float delay);
-			float get_delay();
+			void set_delay(long delay);
+			long get_delay();
 
 			void start_tx();
 			void stop_tx();


### PR DESCRIPTION
Fixes https://github.com/bastibl/gr-foo/issues/10

Changes the `d_interval` variable from `float` to a `long` in Periodic Message Source and Random Periodic Message Source, including the grc block, getters, and setters.

This lets gr-foo compile with boost 1.67 and beyond.