### PR TITLE
Update version of gnuradio dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 ########################################################################
 # Install directories
 ########################################################################
-find_package(Gnuradio "3.8" REQUIRED COMPONENTS blocks analog filter fft)
+find_package(Gnuradio "3.9" REQUIRED COMPONENTS blocks analog filter fft)
 include(GrVersion)
 
 include(GrPlatform) #define LIB_SUFFIX


### PR DESCRIPTION
Gnuradio on master have changed their version number to 3.9 in commit https://github.com/gnuradio/gnuradio/commit/f1475ce5eea60d4780621b5f62b8c7a226cd29a9. This pull request updates gr-foo's CMakeLists.txt version check to match. This is for issue https://github.com/bastibl/gr-foo/issues/17.