### PR TITLE
Added a new block: Pad Tagged Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ I used this block for automated performance tests with no-GUI flow graphs.
 
 
 
+### Pad Tagged Stream
+
+Pads an incoming tagged stream with 0s to the set buffer size.
+Padding is applied to the tail of the tagged stream.
+
+This is useful when transmitting packetized data by using a Pluto as SDR.
+The Pluto does currently not support a partial buffer flush triggered by an incoming tagged stream.
+Therefore this block pads incoming tagged stream to fill the Pluto buffer to enforce an immediate transmission.
+
+
+
 ### Installation
 
 ```

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -29,5 +29,5 @@ install(FILES
 	foo_packet_dropper.block.yml
 	foo_periodic_msg_source.block.yml
 	foo_selector.block.yml
-	DESTINATION share/gnuradio/grc/blocks
+    foo_pad_tagged_stream.block.yml	DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/foo_pad_tagged_stream.block.yml
+++ b/grc/foo_pad_tagged_stream.block.yml
@@ -15,6 +15,7 @@ parameters:
 - id: buffer_size
   label: Buffer Size
   dtype: int
+  default: '0x8000'
 - id: len_tag_name
   label: Length Tag Key
   dtype: string

--- a/grc/foo_pad_tagged_stream.block.yml
+++ b/grc/foo_pad_tagged_stream.block.yml
@@ -1,0 +1,45 @@
+id: foo_pad_tagged_stream
+label: Pad Tagged Stream
+category: '[Foo]'
+
+templates:
+  imports: import foo
+  make: foo.pad_tagged_stream(${buffer_size}, ${len_tag_name})
+
+#  Make one 'parameters' list entry for every parameter you want settable from the GUI.
+#     Keys include:
+#     * id (makes the value accessible as \$keyname, e.g. in the make entry)
+#     * label (label shown in the GUI)
+#     * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
+parameters:
+- id: buffer_size
+  label: Buffer Size
+  dtype: int
+- id: len_tag_name
+  label: Length Tag Key
+  dtype: string
+
+#  Make one 'inputs' list entry per input and one 'outputs' list entry per output.
+#  Keys include:
+#      * label (an identifier for the GUI)
+#      * domain (optional - stream or message. Default is stream)
+#      * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
+#      * vlen (optional - data stream vector length. Default is 1)
+#      * optional (optional - set to 1 for optional inputs. Default is 0)
+inputs:
+- label: in
+  domain: stream
+  dtype: complex
+  vlen: 1
+  optional: 0
+
+outputs:
+- label: out
+  domain: stream
+  dtype: complex
+  vlen: 1
+  optional: 0
+
+#  'file_format' specifies the version of the GRC yml format used in the file
+#  and should usually not be changed.
+file_format: 1

--- a/include/foo/CMakeLists.txt
+++ b/include/foo/CMakeLists.txt
@@ -31,5 +31,5 @@ install(FILES
 	random_periodic_msg_source.h
 	rtt_measure.h
 	wireshark_connector.h
-	DESTINATION include/foo
+    pad_tagged_stream.h	DESTINATION include/foo
 )

--- a/include/foo/pad_tagged_stream.h
+++ b/include/foo/pad_tagged_stream.h
@@ -1,0 +1,55 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2019 "Cyancali".
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_FOO_PAD_TAGGED_STREAM_H
+#define INCLUDED_FOO_PAD_TAGGED_STREAM_H
+
+#include <foo/api.h>
+#include <gnuradio/tagged_stream_block.h>
+
+namespace gr {
+  namespace foo {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup foo
+     *
+     */
+    class FOO_API pad_tagged_stream : virtual public gr::tagged_stream_block
+    {
+     public:
+      typedef boost::shared_ptr<pad_tagged_stream> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of foo::pad_tagged_stream.
+       *
+       * To avoid accidental use of raw pointers, foo::pad_tagged_stream's
+       * constructor is in a private implementation
+       * class. foo::pad_tagged_stream::make is the public interface for
+       * creating new instances.
+       */
+      static sptr make(int buffer_size, const std::string len_tag_name);
+    };
+
+  } // namespace foo
+} // namespace gr
+
+#endif /* INCLUDED_FOO_PAD_TAGGED_STREAM_H */
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,6 +39,7 @@ list(APPEND foo_sources
     random_periodic_msg_source_impl.cc
     rtt_measure_impl.cc
     wireshark_connector_impl.cc
+    pad_tagged_stream_impl.cc
 )
 
 set(foo_sources "${foo_sources}" PARENT_SCOPE)

--- a/lib/pad_tagged_stream_impl.cc
+++ b/lib/pad_tagged_stream_impl.cc
@@ -75,11 +75,19 @@ namespace gr {
 
       noutput_items = d_buf_len;
 
+
       memcpy((void*)out, (const void*)in, ninput_items[0]);
-      if (ninput_items[0] < noutput_items) memset((void*) (out+ninput_items[0]), 0, noutput_items-ninput_items[0]);
+
+      if (ninput_items[0] <= noutput_items)
+      {
+        memset((void*) (out+ninput_items[0]), 0, noutput_items-ninput_items[0]);
+      }
+      else // ninput_items[0] > noutput_items
+      {
+        std::cout << "PadTaggedStream: Warning - Tagged stream is longer than buffer" << std::endl;
+      }
 
       return noutput_items;
-
     }
 
   } /* namespace foo */

--- a/lib/pad_tagged_stream_impl.cc
+++ b/lib/pad_tagged_stream_impl.cc
@@ -1,0 +1,86 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2019 "Cyancali".
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "pad_tagged_stream_impl.h"
+
+namespace gr {
+  namespace foo {
+
+    pad_tagged_stream::sptr
+    pad_tagged_stream::make(int buffer_size, const std::string len_tag_name)
+    {
+      return gnuradio::get_initial_sptr
+        (new pad_tagged_stream_impl(buffer_size, len_tag_name));
+    }
+
+
+    /*
+     * The private constructor
+     */
+    pad_tagged_stream_impl::pad_tagged_stream_impl(int buffer_size, const std::string len_tag_name)
+      : gr::tagged_stream_block("pad_tagged_stream",
+                                gr::io_signature::make(1, 1, sizeof(gr_complex)),
+                                gr::io_signature::make(1, 1, sizeof(gr_complex)),
+                                len_tag_name),
+        d_buf_len(buffer_size),
+        d_len_tag(len_tag_name)
+    {
+        set_tag_propagation_policy(TPP_DONT);
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    pad_tagged_stream_impl::~pad_tagged_stream_impl()
+    {
+    }
+
+    int
+    pad_tagged_stream_impl::calculate_output_stream_length(const gr_vector_int &ninput_items)
+    {
+      return d_buf_len;
+    }
+
+    int
+    pad_tagged_stream_impl::work (int noutput_items,
+                       gr_vector_int &ninput_items,
+                       gr_vector_const_void_star &input_items,
+                       gr_vector_void_star &output_items)
+    {
+      const gr_complex *in = (const gr_complex *) input_items[0];
+      gr_complex *out = (gr_complex *) output_items[0];
+
+      noutput_items = d_buf_len;
+
+      memcpy((void*)out, (const void*)in, ninput_items[0]);
+      if (ninput_items[0] < noutput_items) memset((void*) (out+ninput_items[0]), 0, noutput_items-ninput_items[0]);
+
+      return noutput_items;
+
+    }
+
+  } /* namespace foo */
+} /* namespace gr */
+

--- a/lib/pad_tagged_stream_impl.cc
+++ b/lib/pad_tagged_stream_impl.cc
@@ -76,7 +76,7 @@ namespace gr {
       noutput_items = d_buf_len;
 
 
-      memcpy((void*)out, (const void*)in, ninput_items[0]);
+      memcpy((void*)out, (const void*)in, std::min(d_buf_len, ninput_items[0]));
 
       if (ninput_items[0] <= noutput_items)
       {

--- a/lib/pad_tagged_stream_impl.cc
+++ b/lib/pad_tagged_stream_impl.cc
@@ -47,6 +47,7 @@ namespace gr {
         d_buf_len(buffer_size),
         d_len_tag(len_tag_name)
     {
+        set_min_output_buffer(buffer_size*2);
         set_tag_propagation_policy(TPP_DONT);
     }
 

--- a/lib/pad_tagged_stream_impl.h
+++ b/lib/pad_tagged_stream_impl.h
@@ -1,0 +1,52 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2019 "Cyancali".
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_FOO_PAD_TAGGED_STREAM_IMPL_H
+#define INCLUDED_FOO_PAD_TAGGED_STREAM_IMPL_H
+
+#include <foo/pad_tagged_stream.h>
+
+namespace gr {
+  namespace foo {
+
+    class pad_tagged_stream_impl : public pad_tagged_stream
+    {
+     private:
+      int d_buf_len;
+      std::string d_len_tag;
+
+     public:
+      pad_tagged_stream_impl(int buffer_size, const std::string len_tag_name);
+      ~pad_tagged_stream_impl();
+
+      int calculate_output_stream_length(const gr_vector_int &ninput_items);
+
+      // Where all the action really happens
+      int work(int noutput_items,
+           gr_vector_int &ninput_items,
+           gr_vector_const_void_star &input_items,
+           gr_vector_void_star &output_items);
+    };
+
+  } // namespace foo
+} // namespace gr
+
+#endif /* INCLUDED_FOO_PAD_TAGGED_STREAM_IMPL_H */
+

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,3 +42,4 @@ include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-foo)
 set(GR_TEST_PYTHON_DIRS ${CMAKE_BINARY_DIR}/swig)
+GR_ADD_TEST(qa_pad_tagged_stream ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_pad_tagged_stream.py)

--- a/python/qa_pad_tagged_stream.py
+++ b/python/qa_pad_tagged_stream.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 "Cyancali".
+#
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+import foo_swig as foo
+
+class qa_pad_tagged_stream(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_001_t(self):
+        # set up fg
+        self.tb.run()
+        # check data
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_pad_tagged_stream)

--- a/swig/foo_swig.i
+++ b/swig/foo_swig.i
@@ -17,6 +17,7 @@
 #include "foo/random_periodic_msg_source.h"
 #include "foo/rtt_measure.h"
 #include "foo/wireshark_connector.h"
+#include "foo/pad_tagged_stream.h"
 %}
 
 
@@ -39,3 +40,5 @@ GR_SWIG_BLOCK_MAGIC2(foo, periodic_msg_source);
 GR_SWIG_BLOCK_MAGIC2(foo, random_periodic_msg_source);
 GR_SWIG_BLOCK_MAGIC2(foo, rtt_measure);
 GR_SWIG_BLOCK_MAGIC2(foo, wireshark_connector);
+%include "foo/pad_tagged_stream.h"
+GR_SWIG_BLOCK_MAGIC2(foo, pad_tagged_stream);


### PR DESCRIPTION
A Pluto SDR does not support a partial buffer flash by using a tagged stream. Therefore this block can be added to the flowchart to pad an incoming tagged stream with 0s at the tail. This fills the buffer and enforces an immediate transmission.

The buffer size and the name of the length tag is the required input for this block. The buffer size needs to be the same size than the Pluto buffer.

Issue was discussed here: https://github.com/bastibl/gr-ieee802-15-4/issues/43