### PR TITLE
Fix use of VLA

### DIFF
--- a/lib/random_periodic_msg_source_impl.cc
+++ b/lib/random_periodic_msg_source_impl.cc
@@ -93,13 +93,13 @@ random_periodic_msg_source_impl::run(random_periodic_msg_source_impl *instance) 
 // Generate a random message
 pmt::pmt_t
 random_periodic_msg_source_impl::generate_msg() {
-	uint8_t vec[d_msg_len];
+	std::vector<uint8_t> vec(d_msg_len);
 
 	for(int i = 0; i < d_msg_len; i++) {
 		vec[i] = d_randbytes();
 	}
 
-	pmt::pmt_t blob = pmt::make_blob(vec, d_msg_len);
+	pmt::pmt_t blob = pmt::make_blob(vec.data(), d_msg_len);
 	return pmt::cons(pmt::PMT_NIL, blob);
 }
 void


### PR DESCRIPTION
In my effort to build *gr-ieee802-11* with MSVC-2019, I gathered I need this OOT block too.

It builds fine with clang-cl on Windows, but stops with MSVC not supporting VLA (*Variable Length Arrays*). Error was:
```
random_periodic_msg_source_impl.cc(96): error C2131: expression did not evaluate to a constant
random_periodic_msg_source_impl.cc(96): note: failure was caused by a read of a variable outside its lifetime
random_periodic_msg_source_impl.cc(96): note: see usage of 'this'
random_periodic_msg_source_impl.cc(99): error C3863: array type 'uint8_t [this->8]' is not assignable
```

Simply switching to `std::vector` , it compiles using MSVC-2019 too. 

With my limited C++ knowledge, I hope and believe it's almost the same (but a bit slower).
Or maybe using `alloca()` would be better?