### PR TITLE
fix CMake pybind11 configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,16 @@ if(APPLE)
 endif(APPLE)
 
 ########################################################################
+# PyBind11 Related
+########################################################################
+
+find_package(pybind11 REQUIRED)
+execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c
+    "try:\n import numpy\n import os\n inc_path = numpy.get_include()\n if os.path.exists(os.path.join(inc_path, 'numpy', 'arrayobject.h')):\n  print(inc_path, end='')\nexcept:\n pass"
+    OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR)
+
+########################################################################
 # Find gnuradio build dependencies
 ########################################################################
 find_package(Doxygen)


### PR DESCRIPTION
Hi,
with reference to issue #30 I investigated the code of gr-satellites, which happens to have few extra lines compared to gr-foo/CMakeLists.txt to load pybind11 code in the buildchain.
This PR fixes issue #30 

Best,
Luca