### PR TITLE
CMakeLists.txt: find build dependency liborc-0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,14 @@ endif(APPLE)
 ########################################################################
 find_package(Doxygen)
 
+find_library(orc_LIBRARY NAMES orc-0.4)
+
+if(orc_LIBRARY)
+    message(STATUS "Found liborc: ${orc_LIBRARY}")
+else()
+    message(FATAL_ERROR "Could not find liborc")
+endif()
+
 ########################################################################
 # Setup doxygen option
 ########################################################################


### PR DESCRIPTION
Hi :)

I encountered this error when building the project: No rule to make target '/usr/lib/x86_64-linux-gnu/liborc-0.4.so'.
This is because liborc was not installed on my Ubuntu 20.04 distribution.
Therefore, I thought it would be helpful to have a more user-friendly warning before running the make command. That's why I added this check.

I hope it will be useful for other users :)