### PR TITLE
wireshark: add support for an IEEE 802.15.4 TAP Header

### DIFF
--- a/grc/foo_wireshark_connector.block.yml
+++ b/grc/foo_wireshark_connector.block.yml
@@ -9,8 +9,8 @@ parameters:
     label: Technology
     dtype: enum
     default: '127'
-    options: ['127', '195']
-    option_labels: [WiFi, ZigBee]
+    options: ['127', '195', '283']
+    option_labels: [WiFi, ZigBee, ZigBeeTap]
 -   id: debug
     label: Debug
     dtype: bool

--- a/include/foo/wireshark_connector.h
+++ b/include/foo/wireshark_connector.h
@@ -25,7 +25,8 @@ namespace foo {
 
 enum LinkType {
 	WIFI = 127,
-	ZIGBEE = 195
+	ZIGBEE = 195,
+	ZIGBEE_TAP = 283
 };
 
 class FOO_API wireshark_connector : virtual public gr::block

--- a/lib/wireshark_connector_impl.h
+++ b/lib/wireshark_connector_impl.h
@@ -104,6 +104,15 @@ namespace foo {
 	};
 	#pragma pack(pop)
 
+	#pragma pack(push, 1)
+	struct tap_tlv_lqi {
+		uint16_t type; // LQI_TYPE = 10
+		uint16_t length; // 1
+		uint8_t lqi;
+		uint8_t padding[3]; // Should be 0 padded
+	};
+	#pragma pack(pop)
+
 }  // namespace foo
 }  // namespace gr
 

--- a/lib/wireshark_connector_impl.h
+++ b/lib/wireshark_connector_impl.h
@@ -75,6 +75,35 @@ namespace foo {
 	};
 	#pragma pack(pop)
 
+	#pragma pack(push, 1)
+	// An 802.15.4 TAP header as defined in https://gitlab.com/exegin/ieee802-15-4-tap/
+	struct tap_hdr {
+		uint8_t version;
+		uint8_t reserved;
+		uint16_t length;
+	};
+	#pragma pack(pop)
+
+
+	#pragma pack(push, 1)
+	struct tap_tlv_fcs {
+		uint16_t type; // FCS_TYPE = 0
+		uint16_t length; // 1
+		uint8_t fcs_type; // 0 = None, 1 = 16-bit CRC, 2 = 32-bit CRC
+		uint8_t padding[3]; // Should be 0 padded
+	};
+	#pragma pack(pop)
+
+	#pragma pack(push, 1)
+	struct tap_tlv_channel {
+		uint16_t type; // CHANNEL_ASSIGNMENT = 3
+		uint16_t length; // 3
+		uint16_t channel_number;
+		uint8_t channel_page;
+		uint8_t padding; // Should be 0 padded
+	};
+	#pragma pack(pop)
+
 }  // namespace foo
 }  // namespace gr
 

--- a/python/bindings/docstrings/wireshark_connector_pydoc_template.h
+++ b/python/bindings/docstrings/wireshark_connector_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2024 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -7,7 +7,7 @@
  *
  */
 #include "pydoc_macros.h"
-#define D(...) DOC(gr,foo, __VA_ARGS__ )
+#define D(...) DOC(gr, foo, __VA_ARGS__)
 /*
   This file contains placeholders for docstrings for the Python bindings.
   Do not edit! These were automatically extracted during the binding process
@@ -15,13 +15,10 @@
  */
 
 
- 
- static const char *__doc_gr_foo_wireshark_connector = R"doc()doc";
+static const char* __doc_gr_foo_wireshark_connector = R"doc()doc";
 
 
- static const char *__doc_gr_foo_wireshark_connector_wireshark_connector = R"doc()doc";
+static const char* __doc_gr_foo_wireshark_connector_wireshark_connector_0 = R"doc()doc";
 
 
- static const char *__doc_gr_foo_wireshark_connector_make = R"doc()doc";
-
-  
+static const char* __doc_gr_foo_wireshark_connector_make = R"doc()doc";

--- a/python/bindings/wireshark_connector_python.cc
+++ b/python/bindings/wireshark_connector_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2024 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(wireshark_connector.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(10414a436e555bc27b41e65120989433)                     */
+/* BINDTOOL_HEADER_FILE_HASH(fcd645d2eb8f7772de5e8ded1ce89be8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -30,39 +30,28 @@ namespace py = pybind11;
 void bind_wireshark_connector(py::module& m)
 {
 
-    using wireshark_connector    = ::gr::foo::wireshark_connector;
+    using wireshark_connector = ::gr::foo::wireshark_connector;
 
 
-    py::class_<wireshark_connector, gr::block, gr::basic_block,
-        std::shared_ptr<wireshark_connector>>(m, "wireshark_connector", D(wireshark_connector))
+    py::class_<wireshark_connector,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<wireshark_connector>>(
+        m, "wireshark_connector", D(wireshark_connector))
 
         .def(py::init(&wireshark_connector::make),
-           py::arg("type"),
-           py::arg("debug") = false,
-           D(wireshark_connector,make)
-        )
-        
-
+             py::arg("type"),
+             py::arg("debug") = false,
+             D(wireshark_connector, make))
 
 
         ;
 
-    py::enum_<::gr::foo::LinkType>(m,"LinkType")
-        .value("WIFI", ::gr::foo::WIFI) // 127
-        .value("ZIGBEE", ::gr::foo::ZIGBEE) // 195
-        .export_values()
-    ;
+    py::enum_<::gr::foo::LinkType>(m, "LinkType")
+        .value("WIFI", ::gr::foo::LinkType::WIFI)             // 127
+        .value("ZIGBEE", ::gr::foo::LinkType::ZIGBEE)         // 195
+        .value("ZIGBEE_TAP", ::gr::foo::LinkType::ZIGBEE_TAP) // 283
+        .export_values();
 
     py::implicitly_convertible<int, ::gr::foo::LinkType>();
-
-
-
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This adds a new ZIGBEE_TAP link type to the wireshark connector block, prefixing an [802.15.4 TAP header](https://gitlab.com/exegin/ieee802-15-4-tap/) to each captured frame.

It'll set the FCS to a 16-bit CRC to be compatible with the current ZIGBEE link type. Optionally, if a "channel" key exists in the pdu's dict, it will append the corresponding channel TLV.

<details><summary>Example tshark decode</summary>
<p>

```
Frame 1: 92 bytes on wire (736 bits), 92 bytes captured (736 bits)
    Encapsulation type: IEEE 802.15.4 Wireless with TAP pseudo-header (206)
    Arrival Time: Aug 16, 2024 21:48:01.551103000 EDT
    UTC Arrival Time: Aug 17, 2024 01:48:01.551103000 UTC
    Epoch Arrival Time: 1723859281.551103000
    [Time shift for this packet: 0.000000000 seconds]
    [Time delta from previous captured frame: 0.000000000 seconds]
    [Time delta from previous displayed frame: 0.000000000 seconds]
    [Time since reference or first frame: 0.000000000 seconds]
    Frame Number: 1
    Frame Length: 92 bytes (736 bits)
    Capture Length: 92 bytes (736 bits)
    [Frame is marked: False]
    [Frame is ignored: False]
    [Protocols in frame: wpan-tap:6lowpan:ipv6:udp:mle]
IEEE 802.15.4 TAP
    Header
        Version: 0
        Reserved: 0
        Length: 20
    FCS type: ITU-T CRC16 (1)
        TLV Type: FCS type (0)
        TLV Length: 1
        FCS Type: ITU-T CRC16 (1)
        Padding: 000000
    Channel assignment: Page: Default (0), Number: 15
        TLV Type: Channel assignment (3)
        TLV Length: 3
        Channel: 15
        Page: Default (0)
        Padding: 00
    [Data Length: 72]
IEEE 802.15.4 Data, Dst: Broadcast, Src: e6:69:73:e4:54:b5:c6:8b
    Frame Control Field: 0xd841, Frame Type: Data, PAN ID Compression, Destination Addressing Mode: Short/16-bit, Frame Version: IEEE Std 802.15.4-2006, Source Addressing Mode: Long/64-bit
        .... .... .... .001 = Frame Type: Data (0x1)
        .... .... .... 0... = Security Enabled: False
        .... .... ...0 .... = Frame Pending: False
        .... .... ..0. .... = Acknowledge Request: False
        .... .... .1.. .... = PAN ID Compression: True
        .... .... 0... .... = Reserved: False
        .... ...0 .... .... = Sequence Number Suppression: False
        .... ..0. .... .... = Information Elements Present: False
        .... 10.. .... .... = Destination Addressing Mode: Short/16-bit (0x2)
        ..01 .... .... .... = Frame Version: IEEE Std 802.15.4-2006 (1)
        11.. .... .... .... = Source Addressing Mode: Long/64-bit (0x3)
    Sequence Number: 139
    Destination PAN: 0x6413
    Destination: 0xffff
    Extended Source: e6:69:73:e4:54:b5:c6:8b (e6:69:73:e4:54:b5:c6:8b)
    FCS: 0x1a57 (Correct)
6LoWPAN, Src: fe80::e469:73e4:54b5:c68b, Dest: ff02::1
    IPHC Header
        011. .... = Pattern: IP header compression (0x03)
        ...1 1... .... .... = Traffic class and flow label: Version, traffic class, and flow label compressed (0x3)
        .... .1.. .... .... = Next header: Compressed
        .... ..11 .... .... = Hop limit: 255 (0x3)
        .... .... 0... .... = Context identifier extension: False
        .... .... .0.. .... = Source address compression: Stateless
        .... .... ..11 .... = Source address mode: Compressed (0x0003)
        .... .... .... 1... = Multicast address compression: True
        .... .... .... .0.. = Destination address compression: Stateless
        .... .... .... ..11 = Destination address mode: 8-bits inline (0x0003)
        [Source context: fe80::]
        [Destination context: fe80::]
    [Source: fe80::e469:73e4:54b5:c68b]
    Destination: ff02::1
    UDP header compression
        1111 0... = Pattern: UDP compression header (0x1e)
        .... .0.. = Checksum: Inline
        .... ..00 = Ports: Inline (0)
    Source port: 19788
    Destination port: 19788
    UDP checksum: 0x0ae8
Internet Protocol Version 6, Src: fe80::e469:73e4:54b5:c68b, Dst: ff02::1
    0110 .... = Version: 6
    .... 0000 0000 .... .... .... .... .... = Traffic Class: 0x00 (DSCP: CS0, ECN: Not-ECT)
        .... 0000 00.. .... .... .... .... .... = Differentiated Services Codepoint: Default (0)
        .... .... ..00 .... .... .... .... .... = Explicit Congestion Notification: Not ECN-Capable Transport (0)
    .... 0000 0000 0000 0000 0000 = Flow Label: 0x00000
    Payload Length: 53
    Next Header: UDP (17)
    Hop Limit: 255
    Source Address: fe80::e469:73e4:54b5:c68b
    Destination Address: ff02::1
```

</p>
</details> 