### PR TITLE
Add YAML manifest, add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In GNU Radio 3.9+, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,3 +169,7 @@ endif(ENABLE_PYTHON)
 install(FILES cmake/Modules/fooConfig.cmake
     DESTINATION ${CMAKE_MODULES_DIR}/foo
 )
+
+install(FILES MANIFEST.yml
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.yml
+    DESTINATION share/gnuradio/manifests/foo)

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,0 +1,24 @@
+title: The FOO OOT Module
+version: 1.0
+brief: some utility blocks
+tags: # Tags are arbitrary, but look at CGRAN what other authors are using
+  - foo
+author:
+  - Bastian Bloessl <bloessl@ccs-labs.org>
+copyright_owner:
+  - Bastian Bloessl
+license: GPL-3.0-or-later
+gr_supported_version:
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+repo: https://github.com/bastibl/gr-foo.git
+website: https://github.com/bastibl/gr-foo
+icon: http://www.ccs-labs.org/projects/wime/wime.png
+description: |-
+  This is a collection of custom blocks that are not directly associated with a project. For sample applications see:
+
+  https://github.com/bastibl/gr-ieee802-11
+  https://github.com/bastibl/gr-ieee802-15-4
+file_format: 1


### PR DESCRIPTION
1. YAML manifest is installed and will be used by GRC-Qt for its OOT module browser
2. Force checkouts on Windows to use Unix-style line endings so that the Python binding header hash check does not fail